### PR TITLE
Cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.11)
+
+project(PacmanGame)
+
+add_executable(pacman Main.cpp Game.cpp Pacman.cpp Ghost.cpp GhostAI.cpp Map.cpp Renderer.cpp TextureManager.cpp AudioManager.cpp)
+target_include_directories(pacman PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# sdl2
+find_package(SDL2 CONFIG REQUIRED)
+target_link_libraries(pacman
+        PRIVATE
+        $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+        $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+)
+
+# sdl2-image
+find_package(SDL2_image CONFIG REQUIRED)
+target_link_libraries(pacman PRIVATE $<IF:$<TARGET_EXISTS:SDL2_image::SDL2_image>,SDL2_image::SDL2_image,SDL2_image::SDL2_image-static>)
+
+# sdl2-mixer
+find_package(SDL2_mixer CONFIG REQUIRED)
+target_link_libraries(pacman PRIVATE $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,SDL2_mixer::SDL2_mixer-static>)
+
+# sdl2-ttf
+find_package(SDL2_ttf CONFIG REQUIRED)
+target_link_libraries(pacman PRIVATE $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)

--- a/README.md
+++ b/README.md
@@ -2,92 +2,99 @@ Recreación fiel del juego arcade clásico Pac-Man (1980) usando C++ y SDL2.
 
 ## Controles
 
-| Tecla | Acción |
-|-------|--------|
-| ↑ / W | Mover arriba |
-| ↓ / S | Mover abajo |
-| ← / A | Mover izquierda |
-| → / D | Mover derecha |
-| ESC | Salir del juego |
+| Tecla | Acción                   |
+|-------|--------------------------|
+| ↑ / W | Mover arriba             |
+| ↓ / S | Mover abajo              |
+| ← / A | Mover izquierda          |
+| → / D | Mover derecha            |
+| ESC   | Salir del juego          |
 | ENTER | Reiniciar (en Game Over) |
 
 ## Sonidos Utilizados
 
-| Archivo | Cuándo se reproduce |
-|---------|---------------------|
-| `startup.ogg` | Al iniciar el juego (melodía de inicio) |
-| `eating.wav` | Cada vez que Pac-Man come un dot |
-| `powerup.wav` | Al comer una power pellet |
-| `ghost_eaten.wav` | Al comer un fantasma |
-| `b2b.wav` | Mientras el fantasma vuelve a la casa |
-| `death.wav` | Cuando Pac-Man muere |
-| `fruit.wav` | Al comer la cereza |
-| `siren.ogg` | Sirena de fondo durante el juego |
-| `siren2.ogg` | Sirena rápida (cuando quedan pocos dots) |
-| `high-score.ogg` | Al superar el high score |
+| Archivo           | Cuándo se reproduce                      |
+|-------------------|------------------------------------------|
+| `startup.ogg`     | Al iniciar el juego (melodía de inicio)  |
+| `eating.wav`      | Cada vez que Pac-Man come un dot         |
+| `powerup.wav`     | Al comer una power pellet                |
+| `ghost_eaten.wav` | Al comer un fantasma                     |
+| `b2b.wav`         | Mientras el fantasma vuelve a la casa    |
+| `death.wav`       | Cuando Pac-Man muere                     |
+| `fruit.wav`       | Al comer la cereza                       |
+| `siren.ogg`       | Sirena de fondo durante el juego         |
+| `siren2.ogg`      | Sirena rápida (cuando quedan pocos dots) |
+| `high-score.ogg`  | Al superar el high score                 |
 
 ## Gráficos Utilizados
 
 ## Pac-Man
-| Archivo | Uso |
-|---------|-----|
-| `pac_man_0.png` - `pac_man_4.png` | Animación waka-waka (5 frames) |
+
+| Archivo                             | Uso                            |
+|-------------------------------------|--------------------------------|
+| `pac_man_0.png` - `pac_man_4.png`   | Animación waka-waka (5 frames) |
 | `pacdeath_0.png` - `pacdeath_2.png` | Animación de muerte (3 frames) |
-| `lifecounter_0.png` | Icono de vida en el HUD |
+| `lifecounter_0.png`                 | Icono de vida en el HUD        |
 
 ## Fantasmas
-| Archivo | Uso |
-|---------|-----|
-| `ghost_red_0/1.png` | Blinky (persigue directamente) |
-| `ghost_pink_0/1.png` | Pinky (emboscada adelante) |
-| `ghost_blue_0/1.png` | Inky (emboscada compleja) |
-| `ghost_orange_0/1.png` | Clyde (errático) |
-| `afraid_0/1.png` | Fantasma asustado (vulnerable) |
-| `eyes_*.png` | Ojos volviendo a casa |
+
+| Archivo                | Uso                            |
+|------------------------|--------------------------------|
+| `ghost_red_0/1.png`    | Blinky (persigue directamente) |
+| `ghost_pink_0/1.png`   | Pinky (emboscada adelante)     |
+| `ghost_blue_0/1.png`   | Inky (emboscada compleja)      |
+| `ghost_orange_0/1.png` | Clyde (errático)               |
+| `afraid_0/1.png`       | Fantasma asustado (vulnerable) |
+| `eyes_*.png`           | Ojos volviendo a casa          |
 
 ## Items y UI
-| Archivo | Uso |
-|---------|-----|
-| `pill_0.png` | pellet pequeño |
-| `pill_1.png` | Power pellet (grande) |
-| `spr_cherry_0.png` | Cereza (bonus) |
-| `ready.png` | Texto "READY!" |
-| `game_over.png` | Texto "GAME OVER" |
-| `clear.png` | Texto cuando completas nivel |
-| `background2.png` | Laberinto de fondo |
-| `arcade_n.ttf` | Fuente para puntuación |
+
+| Archivo            | Uso                          |
+|--------------------|------------------------------|
+| `pill_0.png`       | pellet pequeño               |
+| `pill_1.png`       | Power pellet (grande)        |
+| `spr_cherry_0.png` | Cereza (bonus)               |
+| `ready.png`        | Texto "READY!"               |
+| `game_over.png`    | Texto "GAME OVER"            |
+| `clear.png`        | Texto cuando completas nivel |
+| `background2.png`  | Laberinto de fondo           |
+| `arcade_n.ttf`     | Fuente para puntuación       |
 
 ## IA de los Fantasmas
 
 ## Blinky (Rojo) - "Shadow"
+
 - **Comportamiento**: Persigue directamente a Pac-Man
 - **Estrategia**: El más agresivo, siempre va hacia ti
 
 ## Pinky (Rosa) - "Speedy"
+
 - **Comportamiento**: Apunta 4 tiles delante de Pac-Man
 - **Estrategia**: Intenta emboscarte por delante
 
 ## Inky (Cyan) - "Bashful"
+
 - **Comportamiento**: Emboscada compleja usando la posición de Blinky
 - **Estrategia**: Vector desde Blinky → 2 tiles delante de Pac-Man, duplicado
 
 ## Clyde (Naranja) - "Pokey"
-- **Comportamiento**: 
-  - Si está a más de 8 tiles: persigue como Blinky
-  - Si está a 8 tiles o menos: huye a su esquina
+
+- **Comportamiento**:
+    - Si está a más de 8 tiles: persigue como Blinky
+    - Si está a 8 tiles o menos: huye a su esquina
 - **Estrategia**: El más impredecible
 
 ## Puntuación
 
-| Item | Puntos |
-|------|--------|
-| Dot | 10 |
-| Power Pellet | 50 |
-| Cereza | 100 |
-| 1er Fantasma | 200 |
-| 2do Fantasma | 400 |
-| 3er Fantasma | 800 |
-| 4to Fantasma | 1600 |
+| Item         | Puntos |
+|--------------|--------|
+| Dot          | 10     |
+| Power Pellet | 50     |
+| Cereza       | 100    |
+| 1er Fantasma | 200    |
+| 2do Fantasma | 400    |
+| 3er Fantasma | 800    |
+| 4to Fantasma | 1600   |
 
 ## Estructura del Proyecto
 
@@ -134,5 +141,26 @@ Recreación fiel del juego arcade clásico Pac-Man (1980) usando C++ y SDL2.
 - Cereza bonus
 - Todos los sonidos del arcade
 - Transición de niveles
-Este proyecto es una recreación educativa del juego Pac-Man original de Namco (1980).
-PAC-MAN™ & © BANDAI NAMCO Entertainment Inc.
+  Este proyecto es una recreación educativa del juego Pac-Man original de Namco (1980).
+  PAC-MAN™ & © BANDAI NAMCO Entertainment Inc.
+
+## Compilacion
+
+### CMake
+
+#### Windows
+
+Hasta ahora se ha probado con los siguientes compiladores:
+
+- MinGW 11.0 w64
+
+Para compilar usando vcpkg para que se encargue de las dependencias:
+
+```bash
+$ cmake -B build -S . -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic -DCMAKE_TOOLCHAIN_FILE=${VCPKG_HOME}\vcpkg\scripts\buildsystems\vcpkg.cmake 
+$ cmake --build build -j
+```
+
+> [!IMPORTANT]
+> Es importante usar `-DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic` o  `-DVCPKG_TARGET_TRIPLET=x64-mingw-static` para que
+> vcpkg compile la version de SDL2 correspondiente a MinGW.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name" : "pacmangame",
+  "version-string" : "1.0.0",
+  "builtin-baseline" : "f5800a22acb14d7f753e8be12fe5ec2bc999ab44",
+  "dependencies" : [ {
+    "name" : "vcpkg-cmake-config",
+    "version>=" : "2024-05-23"
+  }, {
+    "name" : "vcpkg-cmake",
+    "version>=" : "2024-04-23"
+  }, {
+    "name" : "sdl2",
+    "version>=" : "2.32.8"
+  }, {
+    "name" : "sdl2-mixer",
+    "version>=" : "2.8.1#1"
+  }, {
+    "name" : "sdl2-image",
+    "version>=" : "2.8.8#1"
+  }, {
+    "name" : "sdl2-ttf",
+    "version>=" : "2.24.0"
+  } ]
+}


### PR DESCRIPTION
Solves #1 by adding a CMakeLists.txt, vcpkg.json and updating the README.md to clarify compiler and build instructions for CMake on Windows.

Also applies some formatting to existing tables in README.